### PR TITLE
Update python stan methods

### DIFF
--- a/.github/workflows/workflow-python.yml
+++ b/.github/workflows/workflow-python.yml
@@ -6,6 +6,10 @@ on:
       - '**'
     tags:
       - '**'
+  pull_request:
+    branches:
+      - master
+      - development
 
 jobs:
   models:

--- a/.github/workflows/workflow-r.yml
+++ b/.github/workflows/workflow-r.yml
@@ -6,6 +6,10 @@ on:
       - '**'
     tags:
       - '**'
+  pull_request:
+    branches:
+      - master
+      - development
 
 jobs:
   models:

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ python/build*
 sandbox/*
 TODO.tdl
 .Rhistory
+*.exe
+*.hpp
+*.dll

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,5 +1,6 @@
 import os
 import re
+
 from setuptools import setup
 
 PROJECT_ROOT = os.path.dirname(os.path.realpath(__file__))

--- a/python/src/posteriordb/__init__.py
+++ b/python/src/posteriordb/__init__.py
@@ -1,4 +1,7 @@
 from .posterior_database import PosteriorDatabase
 from .posterior_database_github import PosteriorDatabaseGithub
+from .util import change_stan_backend
 
 __version__ = "0.2.0"
+
+STAN_BACKEND = "cmdstanpy"

--- a/python/src/posteriordb/__init__.py
+++ b/python/src/posteriordb/__init__.py
@@ -7,6 +7,7 @@ STAN_BACKEND = "cmdstanpy"
 
 
 def change_stan_backend(backend):
+    """Update default backend for Stan."""
     assert backend in {"cmdstanpy", "pystan", "pystan2"}
     global STAN_BACKEND
     STAN_BACKEND = backend

--- a/python/src/posteriordb/__init__.py
+++ b/python/src/posteriordb/__init__.py
@@ -1,7 +1,12 @@
 from .posterior_database import PosteriorDatabase
 from .posterior_database_github import PosteriorDatabaseGithub
-from .util import change_stan_backend
 
 __version__ = "0.2.0"
 
 STAN_BACKEND = "cmdstanpy"
+
+
+def change_stan_backend(backend):
+    assert backend in {"cmdstanpy", "pystan", "pystan2"}
+    global STAN_BACKEND
+    STAN_BACKEND = backend

--- a/python/src/posteriordb/model.py
+++ b/python/src/posteriordb/model.py
@@ -6,9 +6,9 @@ from .posterior_database import PosteriorDatabase
 from .posterior_database_github import PosteriorDatabaseGithub
 from .pymc3_model_implementation import PyMC3ModelImplementation
 from .stan_model_implementation import (
-    PyStanModelImplementation,
-    PyStan2ModelImplementation,
     CmdStanPyModelImplementation,
+    PyStan2ModelImplementation,
+    PyStanModelImplementation,
 )
 from .util import drop_keys
 

--- a/python/src/posteriordb/model.py
+++ b/python/src/posteriordb/model.py
@@ -1,6 +1,7 @@
 import os
 from typing import Union
 
+from . import STAN_BACKEND
 from .posterior_database import PosteriorDatabase
 from .posterior_database_github import PosteriorDatabaseGithub
 from .pymc3_model_implementation import PyMC3ModelImplementation
@@ -57,7 +58,7 @@ class Model:
             if backend not in {"cmdstanpy", "pystan", "pystan2", None}:
                 raise TypeError("Invalid backend option: {backend}".format(backend))
             if backend is None:
-                backend = "cmdstanpy"
+                backend = STAN_BACKEND
 
         implementation_info = self._implementations[framework]
         implementation_class = implementations[

--- a/python/src/posteriordb/model_implementation_base.py
+++ b/python/src/posteriordb/model_implementation_base.py
@@ -1,5 +1,4 @@
-from abc import ABC
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 
 class ModelImplementationBase(ABC):

--- a/python/src/posteriordb/posterior.py
+++ b/python/src/posteriordb/posterior.py
@@ -21,9 +21,11 @@ class Posterior:
 
         self.posterior_info = posterior_db.get_posterior_info(name)
 
-        self.model = Model(self.posterior_info["model_name"], posterior_db)
-
         self.data = Dataset(self.posterior_info["data_name"], posterior_db)
+
+        self.model = Model(
+            self.posterior_info["model_name"], posterior_db, data=self.data
+        )
 
         self.information = drop_keys(
             self.posterior_info,

--- a/python/src/posteriordb/posterior_database.py
+++ b/python/src/posteriordb/posterior_database.py
@@ -19,7 +19,7 @@ def temporary_no_assertions(x):
 
 
 def filename(path):
-    """Given a full file path return just the filename without extension """
+    """Given a full file path return just the filename without extension"""
     # with_suffix is needed in case the file has multiple extensions
     return path.with_suffix("").stem
 

--- a/python/src/posteriordb/posterior_database_github.py
+++ b/python/src/posteriordb/posterior_database_github.py
@@ -3,6 +3,7 @@ import json
 import os
 import tempfile
 from pathlib import Path
+
 import requests
 
 

--- a/python/src/posteriordb/stan_model_implementation.py
+++ b/python/src/posteriordb/stan_model_implementation.py
@@ -1,6 +1,7 @@
 from functools import partial
 import json
 
+from .dataset import Dataset
 from .model_implementation_base import ModelImplementationBase
 
 
@@ -37,7 +38,9 @@ class PyStanModelImplementation(ModelImplementationBase):
             if self.data is None and "data" in kwargs:
                 kwargs = kwargs.copy()
                 data = kwargs.pop("data")
-            if not isinstance(self.data, dict):
+            if isinstance(self.data, Dataset):
+                data = self.data.values()
+            elif not isinstance(self.data, dict):
                 with open(self.data, "w") as file_obj:
                     data = json.load(file_obj)
         except ValueError as exc:

--- a/python/src/posteriordb/stan_model_implementation.py
+++ b/python/src/posteriordb/stan_model_implementation.py
@@ -1,5 +1,5 @@
-from functools import partial
 import json
+from functools import partial
 
 from .dataset import Dataset
 from .model_implementation_base import ModelImplementationBase

--- a/python/src/posteriordb/stan_model_implementation.py
+++ b/python/src/posteriordb/stan_model_implementation.py
@@ -1,16 +1,61 @@
+from functools import partial
+import json
+
 from .model_implementation_base import ModelImplementationBase
 
 
-class StanModelImplementation(ModelImplementationBase):
+class PyStan2ModelImplementation(ModelImplementationBase):
     def __init__(self, posterior_db, *, model_code):
         self.posterior_db = posterior_db
         self.model_code = model_code
 
-    def load(self):
+    def load(self, **kwargs):
         try:
             import pystan
         except ImportError:
             raise ValueError("`pystan` needs to be installed")
         model_code_file = self.posterior_db.full_path(self.model_code)
-        stan_model = pystan.StanModel(file=model_code_file)
+        stan_model = pystan.StanModel(file=model_code_file, **kwargs)
+        return stan_model
+
+
+class PyStanModelImplementation(ModelImplementationBase):
+    def __init__(self, posterior_db, *, model_code, data=None):
+        self.posterior_db = posterior_db
+        self.model_code = model_code
+        self.data = data
+
+    def load(self, **kwargs):
+        try:
+            import stan
+        except ImportError:
+            raise ValueError("`pystan` needs to be installed")
+        model_code_file = self.posterior_db.full_path(self.model_code)
+        with open(model_code_file, "r") as file_obj:
+            model_code = file_obj.read()
+        try:
+            if self.data is None and "data" in kwargs:
+                kwargs = kwargs.copy()
+                data = kwargs.pop("data")
+            if not isinstance(self.data, dict):
+                with open(self.data, "w") as file_obj:
+                    data = json.load(file_obj)
+        except ValueError as exc:
+            raise ValueError("invalid data format, use dict or path to json.") from exc
+        stan_model = stan.build(model_code, data)
+        return stan_model
+
+
+class CmdStanPyModelImplementation(ModelImplementationBase):
+    def __init__(self, posterior_db, *, model_code):
+        self.posterior_db = posterior_db
+        self.model_code = model_code
+
+    def load(self, **kwargs):
+        try:
+            from cmdstanpy import CmdStanModel
+        except ImportError:
+            raise ValueError("`cmdstanpy` needs to be installed")
+        model_code_file = self.posterior_db.full_path(self.model_code)
+        stan_model = CmdStanModel(stan_file=model_code_file, **kwargs)
         return stan_model

--- a/python/src/posteriordb/util.py
+++ b/python/src/posteriordb/util.py
@@ -5,3 +5,8 @@ def drop_keys(dct, keys_to_drop):
     new_dct = {k: v for (k, v) in dct.items() if k not in keys_to_drop}
 
     return new_dct
+
+
+def change_stan_backend(backend):
+    assert backend in {"cmdstanpy", "pystan", "pystan2"}
+    STAN_BACKEND = backend

--- a/python/src/posteriordb/util.py
+++ b/python/src/posteriordb/util.py
@@ -5,8 +5,3 @@ def drop_keys(dct, keys_to_drop):
     new_dct = {k: v for (k, v) in dct.items() if k not in keys_to_drop}
 
     return new_dct
-
-
-def change_stan_backend(backend):
-    assert backend in {"cmdstanpy", "pystan", "pystan2"}
-    STAN_BACKEND = backend

--- a/python/tests/integrity_tests/test_integrity.py
+++ b/python/tests/integrity_tests/test_integrity.py
@@ -1,7 +1,8 @@
 import os
 
-from . import helpers
 from posteriordb import PosteriorDatabase
+
+from . import helpers
 
 
 def get_posterior_db():

--- a/python/tests/test_pdb.py
+++ b/python/tests/test_pdb.py
@@ -1,8 +1,9 @@
 import os
 import re
 
-from posteriordb import PosteriorDatabase, PosteriorDatabaseGithub
 from posteriordb.posterior_database_github import get_sha1_hash
+
+from posteriordb import PosteriorDatabase, PosteriorDatabaseGithub
 
 
 def test_posterior_database():


### PR DESCRIPTION
Add backend options for stan framework. (`"pystan", "pystan2", "cmdtanpy"`)

Add CmdStanPy as the default Stan backend.

Change code to work with PyStan (3+).

Adds `posteriordb.STAN_BACKEND` "global" variable that is used automatically by `posterior` class.

To change this value users can call `posteriordb.change_stan_backend` function which accepts `{"cmdstanpy", "pystan", "pystan2"}`