### PR TITLE
Fix implementation info for pymc3 eight schools model

### DIFF
--- a/posterior_database/models/info/eight_schools_centered.info.json
+++ b/posterior_database/models/info/eight_schools_centered.info.json
@@ -19,9 +19,6 @@
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/eight_schools_centered.stan"
-    },
-    "pymc3": {
-      "model_code": "models/pymc3/eight_schools_centered.py"
     }
   },
   "added_by": "Mans Magnusson",

--- a/posterior_database/models/info/eight_schools_noncentered.info.json
+++ b/posterior_database/models/info/eight_schools_noncentered.info.json
@@ -18,6 +18,9 @@
   "model_implementations": {
     "stan": {
       "model_code": "models/stan/eight_schools_noncentered.stan"
+    },
+    "pymc3": {
+      "model_code": "models/pymc3/eight_schools_noncentered.py"
     }
   },
   "added_by": "Mans Magnusson",


### PR DESCRIPTION
Currently the model info for `eight_schools_centered` indicates that it has a pymc3 implementation, when the implementation is actually for `eight_schools_noncentered`. This PR corrects the model info.