### PR TITLE
Fix GLMM_Poisson_model

### DIFF
--- a/posterior_database/models/stan/GLMM_Poisson_model.stan
+++ b/posterior_database/models/stan/GLMM_Poisson_model.stan
@@ -13,7 +13,7 @@ transformed data {
 parameters {
   real<lower=-20, upper=20> alpha;
   real<lower=-10, upper=10> beta1;
-  real<lower=-10, upper=20> beta2;
+  real<lower=-10, upper=10> beta2;
   real<lower=-10, upper=10> beta3;
   vector[n] eps; // Year effects
   real<lower=0, upper=5> sigma;


### PR DESCRIPTION
The uniform prior and the upper limit of the parameter don't match in the current model version.
I don't know for sure if it was supposed to be 10 or 20, but I think for consistency it makes sense that the upper limit should be 10?

No wonder no normalizing flow could ever fit this model correctly!