### PR TITLE
fixing typos

### DIFF
--- a/posterior_database/models/info/rats_model.info.json
+++ b/posterior_database/models/info/rats_model.info.json
@@ -1,7 +1,7 @@
 {
   "name": "rats_model",
-  "keywords": ["Heirarchical", "Normal", "Rats", "Random Effects", "Linear Growth", "Linear"],
-  "title": "Normal Heirarchical Model to Model Rats' Weight Over Time",
+  "keywords": ["Hierarchical", "Normal", "Rats", "Random Effects", "Linear Growth", "Linear"],
+  "title": "Normal Hierarchical Model to Model Rats' Weight Over Time",
   "description": "The model is essentially a random effects linear growth curve.",
   "urls": "https://github.com/stan-dev/example-models/tree/master/bugs_examples/vol1/rats",
   "references": "gelfand1990illustration",

--- a/posterior_database/models/info/seeds_centered_model.info.json
+++ b/posterior_database/models/info/seeds_centered_model.info.json
@@ -1,7 +1,7 @@
 {
   "name": "seeds_centered_model",
   "keywords": ["Random", "Effect", "Logistic", "Regression", "Stanified", "Centered"],
-  "title": "Normal Heirarchical Model to Model Rats' Weight Over Time",
+  "title": "Random Effect Logistic Regression for Seed Germination Proportion",
   "description": "The model is essentially a random effects logistic,\n          allowing for over-dispersion. Models the proportion of germination\n          of different seeds in different root extracts. 'Stanified' & centered:\n          tau replaced by sigma, direct estimation using \n          narrower semi-informative priors, coefficients are centered",
   "urls": "http://www.mrc-bsu.cam.ac.uk/wp-content/uploads/WinBUGS_Vol1.pdf",
   "references": "crowder1978beta",

--- a/posterior_database/models/info/seeds_stanified_model.info.json
+++ b/posterior_database/models/info/seeds_stanified_model.info.json
@@ -1,7 +1,7 @@
 {
   "name": "seeds_stanified_model",
   "keywords": ["Random", "Effect", "Logistic", "Regression", "Stanified"],
-  "title": "Normal Heirarchical Model to Model Rats' Weight Over Time",
+  "title": "Random Effect Logistic Regression for Seed Germination Proportion",
   "description": "The model is essentially a random effects logistic,\n          allowing for over-dispersion. Models the proportion of germination\n          of different seeds in different root extracts. 'Stanified':\n          tau replaced by sigma, direct estimation using \n          narrower semi-informative priors",
   "urls": "http://www.mrc-bsu.cam.ac.uk/wp-content/uploads/WinBUGS_Vol1.pdf",
   "references": "crowder1978beta",


### PR DESCRIPTION
Fixing typos in model info title for the "seeds" model