### PR TITLE
Fixing GLMM_Poisson model prior 

### DIFF
--- a/posterior_database/models/stan/GLMM_Poisson_model.stan
+++ b/posterior_database/models/stan/GLMM_Poisson_model.stan
@@ -13,7 +13,7 @@ transformed data {
 parameters {
   real<lower=-20, upper=20> alpha;
   real<lower=-10, upper=10> beta1;
-  real<lower=-10, upper=20> beta2;
+  real<lower=-10, upper=10> beta2;
   real<lower=-10, upper=10> beta3;
   vector[n] eps; // Year effects
   real<lower=0, upper=5> sigma;


### PR DESCRIPTION
Adjusting prior upper bound for the beta2 parameter in the GLMM_Poisson model so that it matches the corresponding bound for the GLM_Poisson model.