### PR TITLE
Fix argument type in 2pl_latent_reg_irt

### DIFF
--- a/posterior_database/models/stan/2pl_latent_reg_irt.stan
+++ b/posterior_database/models/stan/2pl_latent_reg_irt.stan
@@ -64,7 +64,7 @@ model {
   alpha ~ lognormal(1, 1);
   target += normal_lpdf(beta | 0, 3);
   lambda_adj ~ student_t(3, 0, 1);
-  theta ~ normal(W_adj * lambda_adj, 1);
+  theta ~ normal(W_adj * lambda_adj, 1.0);
   y ~ bernoulli_logit(alpha[ii] .* theta[jj] - beta[ii]);
 }
 generated quantities {

--- a/posterior_database/models/stan/gpcm_latent_reg_irt.stan
+++ b/posterior_database/models/stan/gpcm_latent_reg_irt.stan
@@ -82,7 +82,7 @@ transformed parameters {
 model {
   alpha ~ lognormal(1, 1);
   target += normal_lpdf(beta | 0, 3);
-  theta ~ normal(W_adj * lambda_adj, 1);
+  theta ~ normal(W_adj * lambda_adj, 1.0);
   lambda_adj ~ student_t(3, 0, 1);
   for (n in 1 : N) {
     target += pcm(y[n], theta[jj[n]] .* alpha[ii[n]],

--- a/posterior_database/models/stan/grsm_latent_reg_irt.stan
+++ b/posterior_database/models/stan/grsm_latent_reg_irt.stan
@@ -75,7 +75,7 @@ model {
   alpha ~ lognormal(1, 1);
   target += normal_lpdf(beta | 0, 3);
   target += normal_lpdf(kappa | 0, 3);
-  theta ~ normal(W_adj * lambda_adj, 1);
+  theta ~ normal(W_adj * lambda_adj, 1.0);
   lambda_adj ~ student_t(3, 0, 1);
   for (n in 1 : N) {
     target += rsm(y[n], theta[jj[n]] .* alpha[ii[n]], beta[ii[n]], kappa);


### PR DESCRIPTION
Three irt Stan models had in model block
```
  theta ~ normal(W_adj * lambda_adj, 1);
```
which can cause an error
```
Chain 1 Unrecoverable error evaluating the log probability at the initial value.
Chain 1 Exception: Wrong type assumed! Please file a bug report. (in '/tmp/RtmpV18res/model-69a4b1cb1b309.stan', line 67, column 2 to column 40)
```
which is fixed by changing to
```
  theta ~ normal(W_adj * lambda_adj, 1.0);
```
