### PR TITLE
FIXES model info typo

### DIFF
--- a/posterior_database/models/info/GLM_Poisson_model.info.json
+++ b/posterior_database/models/info/GLM_Poisson_model.info.json
@@ -14,7 +14,7 @@
     },
     "pymc": {
       "model_code": "models/pymc/GLM_Poisson_model.py",
-      "stan_version": ">=5.16.2"
+      "pymc_version": ">=5.16.2"
     }
   },
   "licence": "BSD3"


### PR DESCRIPTION
Fixes model info typo for the pymc GLM_Poisson_model introduced in #267 