### PR TITLE
Fix spec of covid posterior

### DIFF
--- a/posterior_database/posteriors/ecdc0501-covid19imperial_v3.json
+++ b/posterior_database/posteriors/ecdc0501-covid19imperial_v3.json
@@ -10,8 +10,6 @@
     "mu": 14,
     "alpha_hier": 6,
     "kappa": 1,
-    "lockdown": 14,
-    "gamma": 1,
     "y": 14,
     "phi": 1,
     "tau": 1,


### PR DESCRIPTION
Removed 'lockdown' and 'gamma' dimensions from the JSON, which are not used in the actual stan model.